### PR TITLE
fix for directives split across multiple strings in single txt rr

### DIFF
--- a/mkspf.pl
+++ b/mkspf.pl
@@ -63,7 +63,7 @@ sub get_spf {
   my $query = $dns->search( $domain, 'TXT' ) or warn "no TXT record for $domain\n";
   foreach my $rr ( $query->answer ) {
     next unless $rr->type eq 'TXT' and $rr->txtdata =~ /^v=spf1/;
-    process_spf($domain, $rr->txtdata);
+    process_spf($domain, join('', $rr->txtdata));
   }
 }
 


### PR DESCRIPTION
If there is a TXT RR that returns multiple text strings, and a directive happens to span two strings, parsing will fail.  This patch concatenates all the strings before sending to the parse_directive routine.

```
$ dig +short shops.shopify.com txt
"v=spf1 ip4:35.184.170.228 ip4:35.184.254.92 ip4:35.185.32.98 ip4:35.188.30.230 ip4:35.190.163.94 ip4:35.196.108.190 ip4:35.203.111.169 ip4:35.203.117.150 ip4:35.203.12.207 ip4:35.203.29.239 ip4:35.203.3.51 ip4:35.203.35.135 ip4:35.203.68.80 ip4:35.203.94." "235 ip4:35.224.21.218 ip4:35.225.139.175 ip4:35.226.10.253 ip4:35.226.186.69 ip4:35.227.50.232 ip4:35.227.50.75 ip4:35.231.245.77 ip4:104.196.182.217 ip4:104.196.215.101 ip4:104.198.207.207 ~all"
```